### PR TITLE
Refactoring CachedFileSystem als alleinige Factory

### DIFF
--- a/BlueBasics/Classes/FileSystemCaching/CachedFile.cs
+++ b/BlueBasics/Classes/FileSystemCaching/CachedFile.cs
@@ -15,6 +15,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using BlueBasics.Interfaces;
 using System;
 using System.Threading.Tasks;
 using static BlueBasics.ClassesStatic.Generic;
@@ -28,7 +29,7 @@ namespace BlueBasics.Classes.FileSystemCaching;
 /// Thread-sicher durch Double-Checked-Locking.
 /// Instanzen dürfen nur über CachedFileSystem erzeugt werden.
 /// </summary>
-public abstract class CachedFile : IDisposable {
+public abstract class CachedFile : IDisposable, IHasKeyName {
 
     #region Fields
 
@@ -46,7 +47,7 @@ public abstract class CachedFile : IDisposable {
     /// Gibt an, ob der aktuelle Content mit dem Dateiinhalt auf der Platte übereinstimmt.
     /// Wird beim Setzen von Content auf false gesetzt, beim Speichern auf true.
     /// </summary>
-    protected bool _isSaved = true;
+    private bool _isSaved = true;
 
     /// <summary>
     /// Zeitstempel der letzten Dateiversion im Cache.
@@ -121,7 +122,7 @@ public abstract class CachedFile : IDisposable {
     public string Filename { get; }
 
     /// <summary>
-    /// Der FreezedReason kann niemals wieder rückgänig gemacht werden.
+    /// Der FreezedReason kann niemals wieder rückgängig gemacht werden.
     /// Um den FreezedReason zu setzen, die Methode Freeze benutzen.
     /// </summary>
     public string FreezedReason { get; private set; } = string.Empty;
@@ -151,6 +152,16 @@ public abstract class CachedFile : IDisposable {
     }
 
     /// <summary>
+    /// IHasKeyName: Entspricht dem Dateinamen.
+    /// </summary>
+    public virtual string KeyName => Filename;
+
+    /// <summary>
+    /// IHasKeyName: Keys sind case-insensitive.
+    /// </summary>
+    public virtual bool KeyIsCaseSensitive => false;
+
+    /// <summary>
     /// Gibt an, ob das Laden der Datei fehlgeschlagen ist.
     /// </summary>
     public bool LoadFailed { get; protected set; }
@@ -166,6 +177,30 @@ public abstract class CachedFile : IDisposable {
     #region Methods
 
     /// <summary>
+    /// Gibt die zu speichernden Bytes zurück. Standard: aktuell gecachter Content.
+    /// Abgeleitete Klassen überschreiben dies, um ihre serialisierten Daten zu liefern.
+    /// </summary>
+    protected virtual byte[] GetContent() {
+        lock (_lock) {
+            return _content ?? [];
+        }
+    }
+
+    /// <summary>
+    /// Prüft, ob Speichern aktuell erlaubt ist.
+    /// Standard: nicht eingefroren und nicht disposed.
+    /// </summary>
+    public virtual bool IsSaveAbleNow() => !IsFreezed && !IsDisposed;
+
+    /// <summary>
+    /// Markiert den Inhalt als ungespeichert.
+    /// Für Unterklassen, die _isSaved nicht direkt setzen können.
+    /// </summary>
+    protected void MarkDirty() {
+        lock (_lock) { _isSaved = false; }
+    }
+
+    /// <summary>
     /// Disposed alle zugeordneten Ressourcen.
     /// </summary>
     public virtual void Dispose() {
@@ -176,19 +211,18 @@ public abstract class CachedFile : IDisposable {
 
     /// <summary>
     /// Speichert den Inhalt asynchron mit Backup-Rotation.
-    /// Kann von abgeleiteten Klassen überschrieben werden für spezifisches Speicherverhalten.
+    /// Nutzt GetContent() und IsSaveAbleNow().
     /// </summary>
     /// <returns>Leerer String bei Erfolg, Fehlermeldung bei Fehler.</returns>
     public virtual async Task<string> DoExtendedSave() {
+        if (!IsSaveAbleNow()) { return "Nicht speicherbar (IsSaveAbleNow = false)"; }
+
         return await Task.Run(() => {
             try {
-                byte[] dataToWrite;
+                var dataUncompressed = GetContent();
+                if (dataUncompressed.Length == 0) { return "Keine Daten zum Speichern"; }
 
-                lock (_lock) {
-                    if (_content == null || _content.Length == 0) { return "Keine Daten zum Speichern"; }
-                    dataToWrite = MustZipped ? _content.ZipIt() ?? [] : _content;
-                }
-
+                var dataToWrite = MustZipped ? dataUncompressed.ZipIt() ?? [] : dataUncompressed;
                 if (dataToWrite.Length == 0) { return "Komprimierung fehlgeschlagen"; }
 
                 var backup = Filename.FilePath() + Filename.FileNameWithoutSuffix() + ".bak";
@@ -247,12 +281,14 @@ public abstract class CachedFile : IDisposable {
     /// <summary>
     /// Invalidiert den gecachten Inhalt, damit er beim nächsten Zugriff neu geladen wird.
     /// Setzt IsParsed auf false — die Ableitung muss ihre Daten neu verarbeiten.
+    /// Setzt auch _isSaved auf true (lokale Änderungen gelten als verworfen).
     /// </summary>
     public virtual void Invalidate() {
         lock (_lock) {
             _timestamp = null;
             _content = null;
             IsParsed = false;
+            _isSaved = true;
         }
     }
 
@@ -273,19 +309,58 @@ public abstract class CachedFile : IDisposable {
 
     /// <summary>
     /// Speichert den aktuellen Content synchron auf die Platte.
-    /// Bei MustZipped wird automatisch gezippt.
+    /// Nutzt GetContent() und IsSaveAbleNow().
     /// </summary>
     public void Save() {
-        lock (_lock) {
-            if (_content == null || _content.Length == 0) { return; }
+        if (!IsSaveAbleNow()) { return; }
 
-            var dataToWrite = MustZipped ? _content.ZipIt() : _content;
+        lock (_lock) {
+            var data = GetContent();
+            if (data.Length == 0) { return; }
+
+            var dataToWrite = MustZipped ? data.ZipIt() : data;
             if (dataToWrite == null || dataToWrite.Length == 0) { return; }
 
             WriteAllBytes(Filename, dataToWrite);
             _isSaved = true;
             _timestamp = GetFileState(Filename, false, 0.1f);
         }
+    }
+
+    /// <summary>
+    /// Speichert den Inhalt unter einem neuen Dateinamen (synchron).
+    /// Nutzt GetContent() für die Bytes.
+    /// </summary>
+    /// <returns>True wenn erfolgreich.</returns>
+    public bool SaveAs(string filename) {
+        if (IsDisposed) { return false; }
+        if (string.IsNullOrEmpty(filename)) { return false; }
+        if (!IsSaveAbleNow()) { return false; }
+
+        var data = GetContent();
+        if (data.Length == 0) { return false; }
+
+        var dataToWrite = MustZipped ? data.ZipIt() : data;
+        if (dataToWrite == null || dataToWrite.Length == 0) { return false; }
+
+        var backup = filename.FilePath() + filename.FileNameWithoutSuffix() + ".bak";
+        var tmpFile = TempFile(filename.FilePath() + filename.FileNameWithoutSuffix() + ".tmp-" + UserName.ToUpperInvariant());
+
+        if (!WriteAllBytes(tmpFile, dataToWrite)) {
+            DeleteFile(tmpFile, false);
+            return false;
+        }
+
+        if (FileExists(backup)) { DeleteFile(backup, false); }
+        if (FileExists(filename)) { MoveFile(filename, backup, false); }
+
+        if (!MoveFile(tmpFile, filename, false)) {
+            if (FileExists(backup) && !FileExists(filename)) { MoveFile(backup, filename, false); }
+            DeleteFile(tmpFile, false);
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/BlueBasics/Classes/FileSystemCaching/CachedFileSystem.cs
+++ b/BlueBasics/Classes/FileSystemCaching/CachedFileSystem.cs
@@ -35,6 +35,9 @@ namespace BlueBasics.Classes.FileSystemCaching;
 /// <summary>
 /// Hauptklasse für das Caching-System mit automatischer Synchronisation.
 /// Einzige Factory für alle CachedFile-Instanzen.
+/// Existiert als eine einzige globale Instanz (Singleton), die sich über statische
+/// Methoden selbst aktiviert. Pro überwachtem Verzeichnis wird ein eigener
+/// FileSystemWatcher erzeugt.
 /// Unbekannte Dateiendungen werden still ignoriert.
 /// </summary>
 public sealed class CachedFileSystem : IDisposableExtended {
@@ -46,15 +49,10 @@ public sealed class CachedFileSystem : IDisposableExtended {
     /// </summary>
     private const int StaleCheckIntervalMs = 180000;
 
-    private static readonly SemaphoreSlim _globalInstanceLock = new(1, 1);
-    private static readonly ConcurrentDictionary<string, CachedFileSystem> _instances = new();
-
     /// <summary>
-    /// Globaler Timer für die Stale-Prüfung aller gecachten Dateien.
-    /// Ein einziger Timer für alle CachedFileSystem-Instanzen.
+    /// Die einzige globale Instanz.
     /// </summary>
-    private static Timer? _staleCheckTimer;
-    private static readonly object _staleTimerLock = new();
+    private static readonly CachedFileSystem _globalInstance = new();
 
     /// <summary>
     /// Mapping von Datei-Suffix auf den zugehörigen CachedFile-Ableitungstyp.
@@ -62,17 +60,25 @@ public sealed class CachedFileSystem : IDisposableExtended {
     /// </summary>
     private static readonly Lazy<Dictionary<string, Type>> _suffixTypeMap = new(BuildSuffixTypeMap);
 
+    private static Timer? _staleCheckTimer;
+    private static readonly object _staleTimerLock = new();
+
     private readonly ConcurrentDictionary<string, CachedFile> _cachedFiles = new();
+
+    /// <summary>
+    /// Pro überwachtem Verzeichnis ein FileSystemWatcher.
+    /// Key = normalisierter Pfad (Uppercase).
+    /// </summary>
+    private readonly ConcurrentDictionary<string, FileSystemWatcher> _watchers = new();
+
     private readonly ReaderWriterLockSlim _watcherLock = new(LockRecursionPolicy.SupportsRecursion);
     private volatile int _isDisposedFlag;
-    private FileSystemWatcher? _watcher;
 
     #endregion
 
     #region Constructors
 
-    private CachedFileSystem(string watchedDirectory) {
-        WatchedDirectory = watchedDirectory;
+    private CachedFileSystem() {
         StartStaleCheckTimer();
     }
 
@@ -82,106 +88,36 @@ public sealed class CachedFileSystem : IDisposableExtended {
 
     public bool IsDisposed => _isDisposedFlag == 1;
 
-    public string WatchedDirectory {
-        get {
-            if (IsDisposed) { return string.Empty; }
-            return field;
-        }
-        set {
-            if (IsDisposed) { return; }
-
-            value = value.NormalizePath().ToUpperInvariant();
-
-            if (!DirectoryExists(value)) {
-                Develop.DebugPrint(Enums.ErrorType.Error, $"Verzeichnis nicht gefunden: {value}");
-                return;
-            }
-
-            if (!string.IsNullOrEmpty(field) && !IsSubPath(value, field)) {
-                Develop.DebugPrint(Enums.ErrorType.Error, $"Unerlaubte Modifikation: {field} -> {value}");
-                return;
-            }
-
-            _watcherLock.EnterWriteLock();
-            try {
-                DisposeWatcher();
-                _instances.TryRemove(field, out _);
-                field = value;
-                InitializeWatcher();
-                _instances.TryAdd(field, this);
-            } finally {
-                _watcherLock.ExitWriteLock();
-                WarmCache();
-            }
-        }
-    } = string.Empty;
-
     #endregion
 
     #region Methods
 
-    /// <summary>
-    /// Disposed alle CachedFileSystem-Instanzen.
-    /// </summary>
-    public static void DisposeAll() {
-        _globalInstanceLock.Wait();
-        try {
-            foreach (var kvp in _instances.Values) {
-                kvp.Dispose();
-            }
-        } finally {
-            _globalInstanceLock.Release();
-        }
-    }
+    // -----------------------------------------------------------------------
+    // Statische API
+    // -----------------------------------------------------------------------
 
     /// <summary>
-    /// Holt oder erstellt eine CachedFileSystem-Instanz für das angegebene Verzeichnis.
+    /// Disposed die globale Instanz und alle Ressourcen.
+    /// </summary>
+    public static void DisposeAll() => _globalInstance.Dispose();
+
+    /// <summary>
+    /// Gibt die globale CachedFileSystem-Instanz zurück und stellt sicher,
+    /// dass das angegebene Verzeichnis überwacht wird.
     /// </summary>
     public static CachedFileSystem Get(string path) {
-        var normalizedPath = path.NormalizePath().ToUpperInvariant();
-
-        if (_instances.TryGetValue(normalizedPath, out var existingInstance)) {
-            return existingInstance;
-        }
-
-        _globalInstanceLock.Wait();
-        try {
-            if (_instances.TryGetValue(normalizedPath, out existingInstance)) {
-                return existingInstance;
-            }
-
-            var parentInstanceKvp = FindParentInstance(normalizedPath);
-            if (parentInstanceKvp is { }) { return parentInstanceKvp; }
-
-            var firstChild = FindChildInstances(normalizedPath);
-            if (firstChild is { }) {
-                firstChild.WatchedDirectory = path;
-                return firstChild;
-            }
-
-            return new CachedFileSystem(path);
-        } finally {
-            _globalInstanceLock.Release();
-        }
+        _globalInstance.EnsureWatcher(path);
+        return _globalInstance;
     }
 
     /// <summary>
     /// Gibt alle gecachten Instanzen eines bestimmten Typs zurück.
-    /// Durchsucht ALLE CachedFileSystem-Instanzen.
     /// </summary>
     public static List<T> GetAll<T>() where T : CachedFile {
         var result = new List<T>();
-
-        foreach (var instance in _instances.Values) {
-            if (instance.IsDisposed) { continue; }
-
-            foreach (var file in instance._cachedFiles.Values) {
-                if (file is T typed) {
-                    result.Add(typed);
-                }
-            }
+        foreach (var file in _globalInstance._cachedFiles.Values) {
+            if (file is T typed) { result.Add(typed); }
         }
-
         return result;
     }
 
@@ -195,8 +131,6 @@ public sealed class CachedFileSystem : IDisposableExtended {
 
     /// <summary>
     /// Startet den globalen Stale-Check-Timer, falls noch nicht aktiv.
-    /// Ein einziger Timer für alle CachedFileSystem-Instanzen.
-    /// Prüft alle gecachten Dateien auf Aktualität und speichert ungespeicherte Änderungen.
     /// </summary>
     public static void StartStaleCheckTimer() {
         lock (_staleTimerLock) {
@@ -233,31 +167,11 @@ public sealed class CachedFileSystem : IDisposableExtended {
 
         var key = normalizedFile.ToUpperInvariant();
 
-        foreach (var instance in _instances.Values) {
-            if (instance.IsDisposed) { continue; }
-            if (instance._cachedFiles.TryRemove(key, out var file)) {
-                file.Dispose();
-                break;
-            }
+        if (_globalInstance._cachedFiles.TryRemove(key, out var file)) {
+            file.Dispose();
         }
 
         return DeleteFile(normalizedFile, false);
-    }
-
-    /// <summary>
-    /// Gibt den Dateinamen der Blockdatei (.blk) für die angegebene Datei zurück.
-    /// </summary>
-    public static string GetBlockFilename(string filename) =>
-        string.IsNullOrEmpty(filename) ? string.Empty :
-        filename.FilePath() + filename.FileNameWithoutSuffix() + ".blk";
-
-    /// <summary>
-    /// Erstellt eine Blockdatei (.blk) für die angegebene Datei mit dem übergebenen Inhalt.
-    /// </summary>
-    public static void CreateBlockFile(string filename, string content) {
-        var blkName = GetBlockFilename(filename);
-        DeleteFile(blkName, 20);
-        WriteAllText(blkName, content, Constants.Win1252, false);
     }
 
     /// <summary>
@@ -265,78 +179,59 @@ public sealed class CachedFileSystem : IDisposableExtended {
     /// </summary>
     /// <returns>True wenn erfolgreich gelöscht.</returns>
     public static bool DeleteBlockFile(string filename) {
-        var blkName = GetBlockFilename(filename);
+        var blkName = CachedTextFile.GetBlockFilename(filename);
         return DeleteFile(blkName, false);
     }
 
     /// <summary>
-    /// Gibt das Alter der Blockdatei in Sekunden zurück.
-    /// -1 wenn keine Blockdatei vorhanden ist.
-    /// </summary>
-    public static double AgeOfBlockFile(string filename) {
-        var blkName = GetBlockFilename(filename);
-        if (!BlueBasics.ClassesStatic.IO.FileExists(blkName)) { return -1; }
-        var f = GetFileInfo(blkName);
-        if (f == null) { return -1; }
-        return Math.Max(0, DateTime.UtcNow.Subtract(f.CreationTimeUtc).TotalSeconds);
-    }
-
-    /// <summary>
-    /// Liest den Inhalt der Blockdatei (.blk).
-    /// </summary>
-    public static string ReadBlockFileContent(string filename) {
-        var blkName = GetBlockFilename(filename);
-        return ReadAllText(blkName, Constants.Win1252);
-    }
-
-    /// <summary>
     /// Callback des globalen Stale-Check-Timers.
-    /// Prüft alle gecachten Dateien auf Aktualität und speichert ungespeicherte Änderungen.
+    /// Reihenfolge:
+    ///   1. IsStale → Invalidate (Änderungen verwerfen) → continue
+    ///   2. Blockfile vorhanden → continue (andere Instanz bearbeitet)
+    ///   3. !IsSaved → DoExtendedSave
     /// </summary>
     private static async void StaleCheckCallback() {
-        foreach (var instance in _instances.Values) {
-            if (instance.IsDisposed) { continue; }
+        foreach (var file in _globalInstance._cachedFiles.Values) {
+            if (file.IsDisposed) { continue; }
 
-            foreach (var file in instance._cachedFiles.Values) {
-                if (file.IsDisposed) { continue; }
+            // 1. IsStale → Änderungen verwerfen (Invalidate setzt _isSaved=true)
+            if (file.IsStale()) {
+                file.Invalidate();
+                continue;
+            }
 
-                // Zuerst ungespeicherte Änderungen sichern
-                if (!file.IsSaved) {
-                    try {
-                        await file.DoExtendedSave().ConfigureAwait(false);
-                    } catch {
-                        // Fehler beim Speichern — beim nächsten Tick erneut versuchen
-                    }
-                }
+            // 2. Blockfile vorhanden → jemand anderes bearbeitet → nicht speichern
+            var blkAge = CachedTextFile.AgeOfBlockFile(file.Filename);
+            if (blkAge is >= 0 and <= 3600) { continue; }
 
-                // Dann Aktualität prüfen
-                if (file.IsStale()) {
-                    file.Invalidate();
+            // 3. Ungespeicherte Änderungen → speichern
+            if (!file.IsSaved) {
+                try {
+                    await file.DoExtendedSave().ConfigureAwait(false);
+                } catch {
+                    // Beim nächsten Tick erneut versuchen
                 }
             }
         }
     }
 
+    // -----------------------------------------------------------------------
+    // Instanz-Methoden
+    // -----------------------------------------------------------------------
+
     public void Dispose() {
         if (Interlocked.CompareExchange(ref _isDisposedFlag, 1, 0) == 1) { return; }
 
-        var lockAcquired = false;
-
+        _watcherLock.EnterWriteLock();
         try {
-            _watcherLock.EnterWriteLock();
-            lockAcquired = true;
-            _instances.TryRemove(WatchedDirectory, out _);
-
-            DisposeWatcher();
+            DisposeAllWatchers();
 
             foreach (var file in _cachedFiles.Values) {
                 file.Dispose();
             }
             _cachedFiles.Clear();
         } finally {
-            if (lockAcquired) {
-                try { _watcherLock.ExitWriteLock(); } catch { }
-            }
+            try { _watcherLock.ExitWriteLock(); } catch { }
         }
 
         _watcherLock.Dispose();
@@ -352,7 +247,7 @@ public sealed class CachedFileSystem : IDisposableExtended {
     }
 
     /// <summary>
-    /// Holt eine gecachte Datei aus dem Cache.
+    /// Holt oder erstellt eine gecachte Datei.
     /// Gibt null zurück, wenn die Datei nicht im Cache ist oder der Typ nicht passt.
     /// </summary>
     public T? GetOrCreate<T>(string filename) where T : CachedFile {
@@ -380,7 +275,7 @@ public sealed class CachedFileSystem : IDisposableExtended {
     }
 
     /// <summary>
-    /// Gibt alle gecachten Dateien zurück, optional gefiltert nach Patterns.
+    /// Gibt alle gecachten Dateipfade zurück, optional gefiltert nach Pattern.
     /// </summary>
     public List<string> GetFiles(string path, List<string>? includePatterns = null) {
         if (IsDisposed) { return []; }
@@ -398,10 +293,78 @@ public sealed class CachedFileSystem : IDisposableExtended {
         return [.. filesInPath.Where(filename => includePatterns.Exists(pattern => MatchesPattern(filename, pattern)))];
     }
 
+    // -----------------------------------------------------------------------
+    // Private Hilfsmethoden
+    // -----------------------------------------------------------------------
+
     /// <summary>
-    /// Erstellt das Suffix-zu-Typ-Mapping per Reflection.
-    /// Berücksichtigt AllowMultiple — eine Klasse kann mehrere Suffixe registrieren.
+    /// Stellt sicher, dass für das angegebene Verzeichnis ein Watcher aktiv ist.
+    /// Wird beim ersten Aufruf von Get(path) ausgeführt.
     /// </summary>
+    private void EnsureWatcher(string path) {
+        if (IsDisposed) { return; }
+
+        var normalizedPath = path.NormalizePath().ToUpperInvariant();
+
+        if (!DirectoryExists(normalizedPath)) {
+            Develop.DebugPrint(Enums.ErrorType.Error, $"Verzeichnis nicht gefunden: {normalizedPath}");
+            return;
+        }
+
+        if (_watchers.ContainsKey(normalizedPath)) { return; }
+
+        _watcherLock.EnterWriteLock();
+        try {
+            if (_watchers.ContainsKey(normalizedPath)) { return; }
+
+            var watcher = CreateWatcher(normalizedPath);
+            _watchers.TryAdd(normalizedPath, watcher);
+        } finally {
+            try { _watcherLock.ExitWriteLock(); } catch { }
+        }
+
+        WarmCache(normalizedPath);
+    }
+
+    private FileSystemWatcher CreateWatcher(string normalizedPath) {
+        var watcher = new FileSystemWatcher(normalizedPath) {
+            NotifyFilter = NotifyFilters.FileName
+                         | NotifyFilters.LastWrite
+                         | NotifyFilters.Size
+                         | NotifyFilters.CreationTime,
+            IncludeSubdirectories = true,
+            InternalBufferSize = 64 * 1024
+        };
+
+        watcher.Created += OnFileCreated;
+        watcher.Changed += OnFileChanged;
+        watcher.Deleted += OnFileDeleted;
+        watcher.Renamed += OnFileRenamed;
+        watcher.Error += (s, e) => OnWatcherError(normalizedPath, e);
+
+        watcher.EnableRaisingEvents = true;
+        return watcher;
+    }
+
+    private void DisposeAllWatchers() {
+        foreach (var kvp in _watchers) {
+            try {
+                kvp.Value.EnableRaisingEvents = false;
+                kvp.Value.Dispose();
+            } catch { }
+        }
+        _watchers.Clear();
+    }
+
+    private void DisposeWatcher(string normalizedPath) {
+        if (_watchers.TryRemove(normalizedPath, out var watcher)) {
+            try {
+                watcher.EnableRaisingEvents = false;
+                Task.Run(watcher.Dispose);
+            } catch { }
+        }
+    }
+
     private static Dictionary<string, Type> BuildSuffixTypeMap() {
         var map = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
 
@@ -417,10 +380,6 @@ public sealed class CachedFileSystem : IDisposableExtended {
         return map;
     }
 
-    /// <summary>
-    /// Erstellt eine CachedFile-Instanz des richtigen Typs basierend auf der Dateiendung.
-    /// Gibt null zurück, wenn das Suffix nicht registriert ist.
-    /// </summary>
     private static CachedFile? CreateCachedFile(string fileName) {
         var suffix = Path.GetExtension(fileName);
 
@@ -439,42 +398,6 @@ public sealed class CachedFileSystem : IDisposableExtended {
         }
     }
 
-    private static CachedFileSystem? FindChildInstances(string parentPath) {
-        foreach (var kvp in _instances) {
-            if (IsSubPath(parentPath, kvp.Key)) {
-                return kvp.Value;
-            }
-        }
-        return null;
-    }
-
-    private static CachedFileSystem? FindParentInstance(string childPath) {
-        CachedFileSystem? bestMatch = null;
-        var longestMatchLength = 0;
-
-        foreach (var kvp in _instances) {
-            if (IsSubPath(kvp.Key, childPath)) {
-                var matchLength = kvp.Key.Length;
-                if (matchLength > longestMatchLength) {
-                    longestMatchLength = matchLength;
-                    bestMatch = kvp.Value;
-                }
-            }
-        }
-        return bestMatch;
-    }
-
-    private static bool IsSubPath(string parentPath, string childPath) {
-        var normalizedParentPath = parentPath.NormalizePath();
-        var normalizedChildPath = childPath.NormalizePath();
-
-        if (normalizedParentPath.Equals(normalizedChildPath, StringComparison.OrdinalIgnoreCase)) {
-            return false;
-        }
-
-        return normalizedChildPath.StartsWith(normalizedParentPath, StringComparison.OrdinalIgnoreCase);
-    }
-
     private static bool MatchesPattern(string fileName, string pattern) {
         var regexPattern = "^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$";
         return Regex.IsMatch(fileName.FileNameWithSuffix(), regexPattern, RegexOptions.IgnoreCase);
@@ -482,7 +405,7 @@ public sealed class CachedFileSystem : IDisposableExtended {
 
     /// <summary>
     /// Fügt eine Datei zum Cache hinzu — immer im richtigen Typ.
-    /// Unbekannte Suffixe werden still ignoriert (return null).
+    /// Unbekannte Suffixe werden still ignoriert.
     /// </summary>
     private CachedFile? AddToCache(string fileName) {
         var normalizedFileName = fileName.NormalizeFile();
@@ -491,7 +414,7 @@ public sealed class CachedFileSystem : IDisposableExtended {
         if (_cachedFiles.TryGetValue(key, out var existing)) { return existing; }
 
         var newFile = CreateCachedFile(normalizedFileName);
-        if (newFile == null) { return null; } // Unbekanntes Suffix → ignorieren
+        if (newFile == null) { return null; }
 
         var added = _cachedFiles.GetOrAdd(key, newFile);
 
@@ -502,60 +425,6 @@ public sealed class CachedFileSystem : IDisposableExtended {
         return added;
     }
 
-    private void DisposeWatcher() {
-        try {
-            _watcherLock.EnterWriteLock();
-            if (_watcher != null) {
-                _watcher.EnableRaisingEvents = false;
-                _watcher.Created -= OnFileCreated;
-                _watcher.Changed -= OnFileChanged;
-                _watcher.Deleted -= OnFileDeleted;
-                _watcher.Renamed -= OnFileRenamed;
-                _watcher.Error -= OnWatcherError;
-
-                var watcherToDispose = _watcher;
-                _watcher = null;
-
-                Task.Run(watcherToDispose.Dispose);
-            }
-        } finally {
-            try { _watcherLock.ExitWriteLock(); } catch { }
-        }
-    }
-
-    private List<string> GetAllMatchingFiles() {
-        var allFiles = Directory.GetFiles(WatchedDirectory, "*.*", SearchOption.AllDirectories);
-        return [.. allFiles.Where(f => IsSupportedSuffix(Path.GetExtension(f)) && ShouldCacheFile(f))];
-    }
-
-    private void InitializeWatcher() {
-        if (IsDisposed) { return; }
-
-        try {
-            _watcherLock.EnterWriteLock();
-            DisposeWatcher();
-
-            _watcher = new FileSystemWatcher(WatchedDirectory) {
-                NotifyFilter = NotifyFilters.FileName
-                             | NotifyFilters.LastWrite
-                             | NotifyFilters.Size
-                             | NotifyFilters.CreationTime,
-                IncludeSubdirectories = true,
-                InternalBufferSize = 64 * 1024
-            };
-
-            _watcher.Created += OnFileCreated;
-            _watcher.Changed += OnFileChanged;
-            _watcher.Deleted += OnFileDeleted;
-            _watcher.Renamed += OnFileRenamed;
-            _watcher.Error += OnWatcherError;
-
-            _watcher.EnableRaisingEvents = true;
-        } finally {
-            try { _watcherLock.ExitWriteLock(); } catch { }
-        }
-    }
-
     private void OnFileChanged(object sender, FileSystemEventArgs e) {
         if (IsDisposed) { return; }
         if (!ShouldCacheFile(e.FullPath)) { return; }
@@ -564,7 +433,6 @@ public sealed class CachedFileSystem : IDisposableExtended {
         if (_cachedFiles.TryGetValue(key, out var file)) {
             file.Invalidate();
         } else {
-            // Neue Datei mit bekanntem Suffix → aufnehmen
             AddToCache(e.FullPath);
         }
     }
@@ -572,7 +440,6 @@ public sealed class CachedFileSystem : IDisposableExtended {
     private void OnFileCreated(object sender, FileSystemEventArgs e) {
         if (IsDisposed) { return; }
         if (!ShouldCacheFile(e.FullPath)) { return; }
-
         AddToCache(e.FullPath);
     }
 
@@ -590,7 +457,7 @@ public sealed class CachedFileSystem : IDisposableExtended {
         AddToCache(e.FullPath);
     }
 
-    private void OnWatcherError(object sender, ErrorEventArgs e) {
+    private void OnWatcherError(string watchedPath, ErrorEventArgs e) {
         if (IsDisposed) { return; }
 
         Task.Run(async () => {
@@ -601,7 +468,7 @@ public sealed class CachedFileSystem : IDisposableExtended {
                 attempts++;
 
                 try {
-                    var currentFiles = GetAllMatchingFiles().ToHashSet(StringComparer.OrdinalIgnoreCase);
+                    var currentFiles = GetAllMatchingFiles(watchedPath).ToHashSet(StringComparer.OrdinalIgnoreCase);
                     var cachedKeys = _cachedFiles.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
                     foreach (var removed in cachedKeys.Except(currentFiles)) {
@@ -619,35 +486,51 @@ public sealed class CachedFileSystem : IDisposableExtended {
                         }
                     }
 
-                    InitializeWatcher();
+                    // Watcher neu erstellen
+                    DisposeWatcher(watchedPath);
+                    var newWatcher = CreateWatcher(watchedPath);
+                    _watchers.TryAdd(watchedPath, newWatcher);
                     return;
                 } catch { }
             } while (attempts < 15);
 
-            Develop.DebugPrint(Enums.ErrorType.Error, $"FileSystemWatcher für '{WatchedDirectory}' konnte nicht wiederhergestellt werden.");
+            Develop.DebugPrint(Enums.ErrorType.Error, $"FileSystemWatcher für '{watchedPath}' konnte nicht wiederhergestellt werden.");
         });
     }
 
     private void RemoveFromCache(string filename) {
-        if (IsDisposed || string.IsNullOrEmpty(WatchedDirectory)) { return; }
+        if (IsDisposed) { return; }
         if (_cachedFiles.TryRemove(filename.NormalizeFile().ToUpperInvariant(), out var file)) {
             file.Dispose();
         }
     }
 
     private bool ShouldCacheFile(string filename) {
-        if (IsDisposed || string.IsNullOrEmpty(WatchedDirectory)) { return false; }
-        return filename.NormalizeFile().StartsWith(WatchedDirectory, StringComparison.OrdinalIgnoreCase);
+        if (IsDisposed) { return false; }
+        var normalizedFile = filename.NormalizeFile();
+
+        // Prüfen ob die Datei zu einem der überwachten Verzeichnisse gehört
+        foreach (var watchedPath in _watchers.Keys) {
+            if (normalizedFile.StartsWith(watchedPath, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    private void WarmCache() {
-        var files = GetAllMatchingFiles();
+    private static List<string> GetAllMatchingFiles(string watchedPath) {
+        var allFiles = Directory.GetFiles(watchedPath, "*.*", SearchOption.AllDirectories);
+        return [.. allFiles.Where(f => IsSupportedSuffix(Path.GetExtension(f)))];
+    }
+
+    private void WarmCache(string normalizedPath) {
+        var files = GetAllMatchingFiles(normalizedPath);
         foreach (var filePath in files) {
             try {
                 AddToCache(filePath);
             } catch {
                 Develop.AbortAppIfStackOverflow();
-                WarmCache();
+                WarmCache(normalizedPath);
             }
         }
     }

--- a/BlueBasics/Classes/FileSystemCaching/CachedTextFile.cs
+++ b/BlueBasics/Classes/FileSystemCaching/CachedTextFile.cs
@@ -16,7 +16,9 @@
 // DEALINGS IN THE SOFTWARE.
 
 using BlueBasics.Attributes;
+using System;
 using System.Text;
+using static BlueBasics.ClassesStatic.IO;
 
 namespace BlueBasics.Classes.FileSystemCaching;
 
@@ -67,6 +69,50 @@ public sealed class CachedTextFile : CachedFile {
     #endregion
 
     #region Methods
+
+    // -----------------------------------------------------------------------
+    // Statische Block-Datei-Methoden
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Gibt den Dateinamen der Blockdatei (.blk) für die angegebene Datei zurück.
+    /// </summary>
+    public static string GetBlockFilename(string filename) =>
+        string.IsNullOrEmpty(filename) ? string.Empty :
+        filename.FilePath() + filename.FileNameWithoutSuffix() + ".blk";
+
+    /// <summary>
+    /// Erstellt eine Blockdatei (.blk) für die angegebene Datei mit dem übergebenen Inhalt.
+    /// </summary>
+    public static void CreateBlockFile(string filename, string content) {
+        var blkName = GetBlockFilename(filename);
+        DeleteFile(blkName, 20);
+        WriteAllText(blkName, content, Constants.Win1252, false);
+    }
+
+    /// <summary>
+    /// Gibt das Alter der Blockdatei in Sekunden zurück.
+    /// -1 wenn keine Blockdatei vorhanden ist.
+    /// </summary>
+    public static double AgeOfBlockFile(string filename) {
+        var blkName = GetBlockFilename(filename);
+        if (!FileExists(blkName)) { return -1; }
+        var f = GetFileInfo(blkName);
+        if (f == null) { return -1; }
+        return Math.Max(0, DateTime.UtcNow.Subtract(f.CreationTimeUtc).TotalSeconds);
+    }
+
+    /// <summary>
+    /// Liest den Inhalt der Blockdatei (.blk).
+    /// </summary>
+    public static string ReadBlockFileContent(string filename) {
+        var blkName = GetBlockFilename(filename);
+        return ReadAllText(blkName, Constants.Win1252);
+    }
+
+    // -----------------------------------------------------------------------
+    // Instanz-Methoden
+    // -----------------------------------------------------------------------
 
     /// <summary>
     /// Gibt den Textinhalt der Datei zurück.
@@ -158,7 +204,6 @@ public sealed class CachedTextFile : CachedFile {
     /// </summary>
     private static bool IsValidUtf8(byte[] content) {
         var i = 0;
-        var hasMultiByte = false;
 
         while (i < content.Length) {
             var b = content[i];
@@ -177,11 +222,9 @@ public sealed class CachedTextFile : CachedFile {
                 if ((content[i + j] & 0xC0) != 0x80) { return false; }
             }
 
-            hasMultiByte = true;
             i += expectedBytes + 1;
         }
 
-        // Wenn nur ASCII: als UTF-8 behandeln (ist kompatibel)
         return true;
     }
 

--- a/BlueBasics/Classes/MultiUserFile.cs
+++ b/BlueBasics/Classes/MultiUserFile.cs
@@ -32,7 +32,7 @@ using static BlueBasics.ClassesStatic.IO;
 
 namespace BlueBasics.Classes;
 
-public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyName, IParseable, INotifyPropertyChanged {
+public abstract class MultiUserFile : CachedFile, IDisposableExtended {
 
     #region Fields
 
@@ -61,7 +61,7 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     #region Constructors
 
     protected MultiUserFile(string filename) : base(filename) {
-        Invalidate(); // Beim Start als "stale" markieren, damit Load_Reload ausgelöst wird
+        Invalidate(); // Beim Start als "stale" markieren
     }
 
     #endregion
@@ -120,16 +120,6 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     }
 
     /// <summary>
-    /// Gibt an, ob der Schlüssel Groß- und Kleinschreibung berücksichtigt.
-    /// </summary>
-    public bool KeyIsCaseSensitive => false;
-
-    /// <summary>
-    /// Entspricht dem Dateinamen
-    /// </summary>
-    public string KeyName => Filename;
-
-    /// <summary>
     /// MultiUserFiles werden nicht gezippt gespeichert.
     /// </summary>
     public override bool MustZipped => false;
@@ -151,7 +141,6 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     /// <summary>
     /// Friert alle Dateien mit dem angegebenen Grund ein.
     /// </summary>
-    /// <param name="reason">Der Grund für das Einfrieren.</param>
     public static void FreezeAll(string reason) {
         foreach (var thisFile in CachedFileSystem.GetAll<MultiUserFile>()) {
             thisFile.Freeze(reason);
@@ -159,16 +148,18 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     }
 
     /// <summary>
-    ///
+    /// Speichert alle MultiUserFiles.
     /// </summary>
-    /// <param name="mustSave">Falls TRUE wird zuvor automatisch ein Speichervorgang mit FALSE eingeleitet, um so viel wie möglich zu speichern - falls eine Datei blokiert ist.</param>
+    /// <param name="mustSave">Falls TRUE wird zuvor automatisch ein Speichervorgang mit FALSE eingeleitet.</param>
     public static void SaveAll(bool mustSave) {
-        if (mustSave) { SaveAll(false); } // Beenden, was geht, dann erst der muss
+        if (mustSave) { SaveAll(false); }
 
         Develop.Message(ErrorType.Info, null, "Formulare", ImageCode.Diskette, "Speichere alle Formulare", 0);
 
         foreach (var thisFile in CachedFileSystem.GetAll<MultiUserFile>()) {
-            thisFile.Save(mustSave);
+            if (!thisFile.IsSaved && thisFile.IsSaveAbleNow()) {
+                Task.Run(() => thisFile.DoExtendedSave()).GetAwaiter().GetResult();
+            }
         }
 
         Develop.Message(ErrorType.Info, null, "Formulare", ImageCode.Häkchen, "Formulare gespeichert", 0);
@@ -193,6 +184,24 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     }
 
     /// <summary>
+    /// Liefert die zu speichernden Bytes: ParseableItems() serialisiert nach Win1252.
+    /// </summary>
+    protected override byte[] GetContent() {
+        var text = ParseableItems().FinishParseable();
+        if (text.Length < 10) { return []; }
+        return Constants.Win1252.GetBytes(text);
+    }
+
+    /// <summary>
+    /// Prüft, ob Speichern aktuell erlaubt ist.
+    /// </summary>
+    public override bool IsSaveAbleNow() {
+        if (!base.IsSaveAbleNow()) { return false; }
+        if (IsLoading) { return false; }
+        return true;
+    }
+
+    /// <summary>
     /// Speichert die Datei über DoExtendedSave mit Serialisierung.
     /// </summary>
     public override async Task<string> DoExtendedSave() {
@@ -200,11 +209,6 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
 
         try {
             if (DateTime.UtcNow.Subtract(Develop.LastUserActionUtc).TotalSeconds < 6) { return "Benutzer-Aktion abwarten"; }
-
-            var dataUncompressed = ParseableItems().FinishParseable();
-            if (dataUncompressed.Length < 10) { return "Zu wenig Daten angekommen"; }
-
-            Content = Constants.Win1252.GetBytes(dataUncompressed);
 
             return await base.DoExtendedSave().ConfigureAwait(false);
         } finally {
@@ -214,24 +218,27 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
 
     /// <summary>
     /// Führt - falls nötig - einen Reload der Datei aus.
-    /// Der Prozess wartet so lange, bis der Reload erfolgreich war.
-    /// Ein bereits eventuell bestehender Ladevorgang wird abgewartet.
     /// </summary>
-    /// <returns>Gibt TRUE zurück, wenn die am Ende der Routine die Datei auf dem aktuellesten Stand ist</returns>
     public bool Load_Reload() {
         if (!_loadSemaphore.Wait(0)) { return true; }
 
         try {
             if (IsParsed && !IsStale()) { return true; }
 
-            // CachedFile-Cache invalidieren, damit frisch von Platte gelesen wird
             Invalidate();
 
             // Lesen über CachedFile.Content und Konvertierung nach Win1252
-            var data = GetContentAsString(Constants.Win1252);
+            var raw = Content;
+            if (raw.Length == 0) { return false; }
+            var data = Constants.Win1252.GetString(raw);
             if (data.Length < 10) { return false; }
 
-            if (!this.Parse(data)) { return false; }
+            // Inline-Parse (ohne IParseable-Extension)
+            if (data.GetAllTags() is not { } tags) { return false; }
+            foreach (var pair in tags) {
+                ParseThis(pair.Key.ToLowerInvariant(), pair.Value);
+            }
+            ParseFinished(data);
 
             IsParsed = true;
 
@@ -247,20 +254,18 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
 
     /// <summary>
     /// Sperrt die Datei zur Bearbeitung.
-    /// Verwendet CachedFileSystem für die Blockdatei-Verwaltung.
     /// </summary>
-    /// <returns>True, wenn die Sperrung erfolgreich war; andernfalls false.</returns>
     public bool LockEditing() {
         if (_lockCount > 0) { return true; }
 
         if (!IsAdministrator()) { return false; }
 
-        if (CachedFileSystem.AgeOfBlockFile(Filename) is < 0 or > 3600) {
+        if (CachedTextFile.AgeOfBlockFile(Filename) is < 0 or > 3600) {
             if (Develop.AllReadOnly) { return true; }
 
             var tmpInhalt = UserName + "\r\n" + DateTime.UtcNow.ToString5() + "\r\nThread: " + Environment.CurrentManagedThreadId + "\r\n" + Environment.MachineName;
             try {
-                CachedFileSystem.CreateBlockFile(Filename, tmpInhalt);
+                CachedTextFile.CreateBlockFile(Filename, tmpInhalt);
                 _inhaltBlockdatei = tmpInhalt;
             } catch {
                 return false;
@@ -274,9 +279,8 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     }
 
     /// <summary>
-    /// Gibt die Analyseergebnisse der Datei zurück.
+    /// Gibt die serialisierbaren Elemente zurück.
     /// </summary>
-    /// <returns>Eine Liste von Schlüssel-Wert-Paaren.</returns>
     public virtual List<string> ParseableItems() {
         List<string> result = [];
 
@@ -291,16 +295,12 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     /// <summary>
     /// Wird aufgerufen, wenn die Analyse abgeschlossen ist.
     /// </summary>
-    /// <param name="parsed">Die analysierten Daten.</param>
     public virtual void ParseFinished(string parsed) {
     }
 
     /// <summary>
     /// Verarbeitet ein Schlüssel-Wert-Paar während der Analyse.
     /// </summary>
-    /// <param name="key">Der Schlüssel.</param>
-    /// <param name="value">Der Wert.</param>
-    /// <returns>True, wenn die Analyse erfolgreich war; andernfalls false.</returns>
     public virtual bool ParseThis(string key, string value) {
         switch (key) {
             case "type":
@@ -322,40 +322,14 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     }
 
     /// <summary>
-    /// Speichert die Datei.
-    /// </summary>
-    /// <param name="mustSave">Ob die Datei erzwungen gespeichert werden soll.</param>
-    /// <returns>True, wenn die Speicherung erfolgreich war; andernfalls false.</returns>
-    public bool Save(bool mustSave) {
-        if (IsSaved) { return true; }
-
-        if (IsFreezed) { return false; }
-        if (IsLoading) { return false; }
-
-        if (IsStale()) { return false; }
-
-        if (!LockEditing()) { return false; }
-
-        var result = Task.Run(() => DoExtendedSave()).GetAwaiter().GetResult();
-        var t = string.IsNullOrEmpty(result);
-
-        return t;
-    }
-
-    /// <summary>
-    /// Speichert die Datei unter einem neuen Namen.
-    /// </summary>
-    /// <param name="filename">Der neue Dateipfad.</param>
-    /// <returns>True, wenn die Speicherung erfolgreich war; andernfalls false.</returns>
-    public bool SaveAs(string filename) => ProcessFile(TrySaveAs, [filename], false, 120).IsSuccessful;
-
-    /// <summary>
     /// Entsperrt die Datei zur Bearbeitung.
     /// </summary>
     public void UnlockEditing() {
         if (!AmIBlocker()) { return; }
 
-        Save(true);
+        if (!IsSaved && IsSaveAbleNow()) {
+            Task.Run(() => DoExtendedSave()).GetAwaiter().GetResult();
+        }
 
         _lockCount--;
 
@@ -366,16 +340,14 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
 
     /// <summary>
     /// Prüft, ob das aktuelle Objekt die Sperrung verwaltet.
-    /// Verwendet CachedFileSystem für die Blockdatei-Verwaltung.
     /// </summary>
-    /// <returns>True, wenn das aktuelle Objekt die Sperrung hält; andernfalls false.</returns>
     internal bool AmIBlocker() {
-        if (CachedFileSystem.AgeOfBlockFile(Filename) is < 0 or > 3600) { return false; }
+        if (CachedTextFile.AgeOfBlockFile(Filename) is < 0 or > 3600) { return false; }
 
         string inhalt;
 
         try {
-            inhalt = CachedFileSystem.ReadBlockFileContent(Filename);
+            inhalt = CachedTextFile.ReadBlockFileContent(Filename);
         } catch {
             return false;
         }
@@ -386,7 +358,6 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     /// <summary>
     /// Ruft das Editing-Ereignis auf.
     /// </summary>
-    /// <param name="e">Die Ereignisargumente.</param>
     protected void OnEditing(EditingEventArgs e) => Editing?.Invoke(this, e);
 
     /// <summary>
@@ -395,9 +366,8 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
     protected virtual void OnLoaded() => Loaded?.Invoke(this, System.EventArgs.Empty);
 
     /// <summary>
-    /// Ruft das PropertyChanged-Ereignis auf.
+    /// Ruft das PropertyChanged-Ereignis auf und markiert die Datei als ungespeichert.
     /// </summary>
-    /// <param name="propertyName">Der Name der geänderten Eigenschaft.</param>
     protected void OnPropertyChanged([CallerMemberName] string propertyName = "unknown") {
         if (IsDisposed) { return; }
         if (IsSaving || IsLoading) { return; }
@@ -409,68 +379,12 @@ public abstract class MultiUserFile : CachedFile, IDisposableExtended, IHasKeyNa
             }
         }
 
-        _isSaved = false;
+        MarkDirty();
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
     /// <summary>
-    /// Liest den Dateiinhalt über CachedFile.Content und konvertiert mit dem angegebenen Encoding.
-    /// </summary>
-    private string GetContentAsString(Encoding encoding) {
-        var content = Content;
-        if (content.Length == 0) { return string.Empty; }
-        return encoding.GetString(content);
-    }
-
-    /// <summary>
-    /// Gibt den Namen der Sicherungsdatei zurück.
-    /// </summary>
-    private static string Backupdateiname(string filename) => string.IsNullOrEmpty(filename) ? string.Empty : filename.FilePath() + filename.FileNameWithoutSuffix() + ".bak";
-
-    /// <summary>
-    /// Versucht die Datei unter einem neuen Namen zu speichern (für SaveAs).
-    /// </summary>
-    private OperationResult TrySaveAs(List<string> affectingFiles, params object?[] args) {
-        if (IsDisposed) { return OperationResult.Failed("Verworfen!"); }
-
-        if (affectingFiles.Count != 1 || affectingFiles[0] is not { } filename) { return OperationResult.FailedInternalError; }
-
-        if (string.IsNullOrEmpty(filename)) { return OperationResult.Failed("Kein Dateinname angekommen"); }
-
-        if (!_saveSemaphore.Wait(0)) { return OperationResult.FailedRetryable("Anderer Speichervorgang läuft"); }
-
-        try {
-            var dataUncompressed = ParseableItems().FinishParseable();
-
-            if (dataUncompressed.Length < 10) { return OperationResult.FailedRetryable("Zu wenig Daten angekommen"); }
-
-            var tmpFileName = TempFile(filename.FilePath() + filename.FileNameWithoutSuffix() + ".tmp-" + UserName.ToUpperInvariant());
-
-            if (Develop.AllReadOnly) { return OperationResult.Success; }
-
-            if (!WriteAllText(tmpFileName, dataUncompressed, Constants.Win1252, false)) {
-                return OperationResult.FailedRetryable("Speicherfehler");
-            }
-
-            if (FileExists(Backupdateiname(filename))) {
-                if (!DeleteFile(Backupdateiname(filename), false)) { return OperationResult.FailedRetryable("Backup konnte nicht gelöscht werden"); }
-            }
-
-            if (FileExists(filename)) {
-                if (!MoveFile(filename, Backupdateiname(filename), false)) { return OperationResult.FailedRetryable("Haupt-Datei konnte nicht zum Backup gemacht werden"); }
-            }
-
-            MoveFile(tmpFileName, filename, true);
-
-            return OperationResult.Success;
-        } finally {
-            _saveSemaphore.Release();
-        }
-    }
-
-    /// <summary>
     /// Entsperrt die Datei vollständig.
-    /// Verwendet CachedFileSystem für die Blockdatei-Verwaltung.
     /// </summary>
     private void UnlockHard() {
         if (CachedFileSystem.DeleteBlockFile(Filename)) {

--- a/BlueControls/Editoren/ConnectedFormulaEditor.cs
+++ b/BlueControls/Editoren/ConnectedFormulaEditor.cs
@@ -252,26 +252,39 @@ public partial class ConnectedFormulaEditor : PadEditor, IIsEditor {
         Table.SaveAll(true);
         MultiUserFile.SaveAll(false);
 
-        Controls.ConnectedFormula.ConnectedFormula? tmpf = null;
+        if (sender == btnSaveAs) {
+            // Bestehendes Formular unter neuem Namen speichern
+            if (Formula == null) {
+                MessageBox.Show("Kein Formular zum Speichern vorhanden");
+                return;
+            }
 
-        if (sender == btnSaveAs) { tmpf = Formula; }
+            SaveTab.ShowDialog();
+            if (!DirectoryExists(SaveTab.FileName.FilePath())) { return; }
+            if (string.IsNullOrEmpty(SaveTab.FileName)) { return; }
 
-        if (sender == btnNeuDB) { tmpf = new Controls.ConnectedFormula.ConnectedFormula(); }
+            if (FileExists(SaveTab.FileName)) { DeleteFile(SaveTab.FileName, true); }
 
-        if (tmpf == null) {
-            MessageBox.Show("Kein Formular zum Speichern vorhanden");
+            Formula.SaveAs(SaveTab.FileName);
+            FormulaSet(SaveTab.FileName, null);
             return;
         }
 
-        SaveTab.ShowDialog();
-        if (!DirectoryExists(SaveTab.FileName.FilePath())) { return; }
-        if (string.IsNullOrEmpty(SaveTab.FileName)) { return; }
+        if (sender == btnNeuDB) {
+            // Neues leeres Formular anlegen
+            SaveTab.ShowDialog();
+            if (!DirectoryExists(SaveTab.FileName.FilePath())) { return; }
+            if (string.IsNullOrEmpty(SaveTab.FileName)) { return; }
 
-        if (FileExists(SaveTab.FileName)) { DeleteFile(SaveTab.FileName, true); }
+            if (FileExists(SaveTab.FileName)) { DeleteFile(SaveTab.FileName, true); }
 
-        tmpf.SaveAs(SaveTab.FileName);
+            var fs = BlueBasics.Classes.FileSystemCaching.CachedFileSystem.Get(SaveTab.FileName.FilePath());
+            var newCf = fs.GetOrCreate<Controls.ConnectedFormula.ConnectedFormula>(SaveTab.FileName);
+            if (newCf == null) { return; }
 
-        FormulaSet(SaveTab.FileName, null);
+            newCf.SaveAs(SaveTab.FileName);
+            FormulaSet(SaveTab.FileName, null);
+        }
     }
 
     private void btnOeffnen_Click(object sender, System.EventArgs e) {

--- a/BlueTable/Classes/Chunk.cs
+++ b/BlueTable/Classes/Chunk.cs
@@ -69,7 +69,6 @@ public class Chunk : CachedFile, IHasKeyName {
     /// Konstruktor für die Factory-Erstellung durch CachedFileSystem (via Activator.CreateInstance).
     /// Leitet MainFileName und ChunkId aus dem vollständigen Dateipfad ab.
     /// </summary>
-    /// <param name="fullPath">Vollständiger Pfad zur Chunk-Datei (z.B. "C:\data\mytable\mychunk.bdbc")</param>
     internal Chunk(string fullPath) : base(fullPath) {
         var chunkFolder = fullPath.FilePath();
         var parentFolder = chunkFolder.TrimEnd('\\').FilePath();
@@ -97,12 +96,16 @@ public class Chunk : CachedFile, IHasKeyName {
 
     public long DataLength => _writeBuffer?.Count ?? Content.Length;
     public bool IsMain => string.Equals(KeyName, TableChunk.Chunk_MainData, StringComparison.OrdinalIgnoreCase);
-    public bool KeyIsCaseSensitive => false;
 
-    public string KeyName {
+    /// <summary>
+    /// IHasKeyName — überschreibt CachedFile.KeyName.
+    /// </summary>
+    public new string KeyName {
         get;
         private set => field = value.ToLowerInvariant();
     }
+
+    public new bool KeyIsCaseSensitive => false;
 
     /// <summary>
     /// Chunks werden immer gezippt gespeichert.
@@ -198,44 +201,6 @@ public class Chunk : CachedFile, IHasKeyName {
         ParseLockData();
     }
 
-    public string Save(string filename) {
-        if (LoadFailed) { return "Chunk wurde nicht korrekt geladen"; }
-        if (Bytes.Count < _minBytes) { return "Zu große Änderungen, sicherheitshalber geblockt"; }
-
-        if (Develop.AllReadOnly) { return string.Empty; }
-
-        try {
-            Develop.SetUserDidSomething();
-
-            // Extrahiere nur die tatsächlichen Datensätze, keine Header-Daten
-            var contentBytes = RemoveHeaderDataTypes([.. Bytes]);
-            if (contentBytes == null || contentBytes.Count < _minBytes) { return "Zu große Änderungen, sicherheitshalber geblockt"; }
-
-            // Neuen Header erstellen
-            var head = GetHeadAndSetEditor();
-            if (head == null || head.Count < 100) { return "Chunk-Kopf konnte nicht erstellt werden"; }
-
-            // Header und Datensätze zusammenführen und komprimieren
-            var datacompressed = head.Concat(contentBytes).ToArray().ZipIt();
-            if (datacompressed == null || datacompressed.Length < 100) { return "Komprimierug der Daten fehlgeschlagen"; }
-
-            Develop.SetUserDidSomething();
-
-            if (!WriteAllBytes(filename, datacompressed)) {
-                return "Speichern fehlgeschlagen";
-            }
-
-            _minBytes = (int)(contentBytes.Count * 0.1);
-
-            Develop.SetUserDidSomething();
-        } catch (Exception ex) {
-            DeleteFile(filename, 20);
-            return ex.Message;
-        }
-
-        return string.Empty;
-    }
-
     public void SaveToByteList(ColumnItem column, RowItem row) {
         if (LoadFailed) { return; }
         if (column.Table is not { IsDisposed: false }) { return; }
@@ -284,7 +249,6 @@ public class Chunk : CachedFile, IHasKeyName {
     /// <summary>
     /// Alle Spaltendaten außer Systeminfo
     /// </summary>
-    /// <param name="c"></param>
     public void SaveToByteList(ColumnItem c) {
         if (LoadFailed) { return; }
 
@@ -294,14 +258,12 @@ public class Chunk : CachedFile, IHasKeyName {
         SaveToByteList(TableDataType.IsFirst, c.IsFirst.ToPlusMinus(), name);
         SaveToByteList(TableDataType.IsKeyColumn, c.IsKeyColumn.ToPlusMinus(), name);
         SaveToByteList(TableDataType.ColumnCaption, c.Caption, name);
-        //SaveToByteList(TableDataType.ColumnFunction, ((int)c.Function).ToString(), name);
         SaveToByteList(TableDataType.DefaultRenderer, c.DefaultRenderer, name);
         SaveToByteList(TableDataType.RendererSettings, c.RendererSettings, name);
         SaveToByteList(TableDataType.CaptionGroup1, c.CaptionGroup1, name);
         SaveToByteList(TableDataType.CaptionGroup2, c.CaptionGroup2, name);
         SaveToByteList(TableDataType.CaptionGroup3, c.CaptionGroup3, name);
         SaveToByteList(TableDataType.MultiLine, c.MultiLine.ToPlusMinus(), name);
-        //SaveToByteList(l, TableDataType.CellInitValue, c.CellInitValue, name);
         SaveToByteList(TableDataType.SortAndRemoveDoubleAfterEdit, c.AfterEditQuickSortRemoveDouble.ToPlusMinus(), name);
         SaveToByteList(TableDataType.DoUcaseAfterEdit, c.AfterEditDoUCase.ToPlusMinus(), name);
         SaveToByteList(TableDataType.AutoCorrectAfterEdit, c.AfterEditAutoCorrect.ToPlusMinus(), name);
@@ -316,7 +278,6 @@ public class Chunk : CachedFile, IHasKeyName {
         SaveToByteList(TableDataType.EditableWithTextInput, c.EditableWithTextInput.ToPlusMinus(), name);
         SaveToByteList(TableDataType.SpellCheckingEnabled, c.SpellCheckingEnabled.ToPlusMinus(), name);
         SaveToByteList(TableDataType.Relationship_to_First, c.Relationship_to_First.ToPlusMinus(), name);
-        //SaveToByteList(TableDataType.ShowUndo, c.ShowUndo.ToPlusMinus(), name);
         SaveToByteList(TableDataType.TextFormatingAllowed, c.TextFormatingAllowed.ToPlusMinus(), name);
         SaveToByteList(TableDataType.ForeColor, c.ForeColor.ToArgb().ToString1(), name);
         SaveToByteList(TableDataType.BackColor, c.BackColor.ToArgb().ToString1(), name);
@@ -328,15 +289,12 @@ public class Chunk : CachedFile, IHasKeyName {
         SaveToByteList(TableDataType.EditableWithDropdown, c.EditableWithDropdown.ToPlusMinus(), name);
         SaveToByteList(TableDataType.DropDownItems, c.DropDownItems.JoinWithCr(), name);
         SaveToByteList(TableDataType.LinkedCellFilter, c.LinkedCellFilter.JoinWithCr(), name);
-        //SaveToByteList(l, TableDataType.OpticalTextReplace, c.OpticalReplace.JoinWithCr(), name);
         SaveToByteList(TableDataType.AutoReplaceAfterEdit, c.AfterEditAutoReplace.JoinWithCr(), name);
         SaveToByteList(TableDataType.RegexCheck, c.RegexCheck, name);
         SaveToByteList(TableDataType.DropdownDeselectAllAllowed, c.DropdownDeselectAllAllowed.ToPlusMinus(), name);
         SaveToByteList(TableDataType.ShowValuesOfOtherCellsInDropdown, c.ShowValuesOfOtherCellsInDropdown.ToPlusMinus(), name);
         SaveToByteList(TableDataType.ColumnQuickInfo, c.QuickInfo, name);
         SaveToByteList(TableDataType.ColumnAdminInfo, c.AdminInfo, name);
-        //SaveToByteList(TableDataType.ColumnSystemInfo, c.SystemInfo, name);
-        //SaveToByteList(l, TableDataType.ColumnContentWidth, c.ContentWidth.ToString(), name);
         SaveToByteList(TableDataType.CaptionBitmapCode, c.CaptionBitmapCode, name);
         SaveToByteList(TableDataType.AllowedChars, c.AllowedChars, name);
         SaveToByteList(TableDataType.MaxTextLength, c.MaxTextLength.ToString1(), name);
@@ -344,26 +302,19 @@ public class Chunk : CachedFile, IHasKeyName {
         SaveToByteList(TableDataType.ColumnTags, c.ColumnTags.JoinWithCr(), name);
         SaveToByteList(TableDataType.EditAllowedDespiteLock, c.EditAllowedDespiteLock.ToPlusMinus(), name);
         SaveToByteList(TableDataType.LinkedTableTableName, c.LinkedTableTableName, name);
-        //SaveToByteList(l, TableDataType.ConstantHeightOfImageCode, c.ConstantHeightOfImageCode, name);
-        //SaveToByteList(l, TableDataType.BehaviorOfImageAndText, ((int)c.BehaviorOfImageAndText).ToString(), name);
         SaveToByteList(TableDataType.DoOpticalTranslation, ((int)c.DoOpticalTranslation).ToString1(), name);
         SaveToByteList(TableDataType.AdditionalFormatCheck, ((int)c.AdditionalFormatCheck).ToString1(), name);
         SaveToByteList(TableDataType.ScriptType, ((int)c.ScriptType).ToString1(), name);
-        //SaveToByteList(l, TableDataType.KeyColumnKey, column.KeyColumnKey.ToString(false), key);
         SaveToByteList(TableDataType.ColumnNameOfLinkedTable, c.ColumnNameOfLinkedTable, name);
-        //SaveToByteList(l, TableDataType.MakeSuggestionFromSameKeyColumn, column.VorschlagsColumn.ToString(false), key);
         SaveToByteList(TableDataType.ColumnAlign, ((int)c.Align).ToString1(), name);
         SaveToByteList(TableDataType.SortType, ((int)c.SortType).ToString1(), name);
-        //SaveToByteList(l, TableDataType.ColumnTimeCode, column.TimeCode, key);
     }
 
     public override string ToString() => KeyName;
 
     /// <summary>
     /// Prüft, ob die Bytes geladen werden konnten.
-    /// Das Laden erfolgt jetzt synchron über CachedFile.Content.
     /// </summary>
-    /// <returns>True, wenn Bytes verfügbar sind, sonst False</returns>
     public bool WaitBytesLoaded() {
         if (LoadFailed) { return false; }
 
@@ -397,66 +348,48 @@ public class Chunk : CachedFile, IHasKeyName {
         return false;
     }
 
+    /// <summary>
+    /// Liefert die zu speichernden unkomprimierten Bytes (Header + Nutzdaten).
+    /// Komprimierung übernimmt DoExtendedSave der Basisklasse (MustZipped = true).
+    /// </summary>
+    protected override byte[] GetContent() {
+        if (LoadFailed) { return []; }
+
+        var contentBytes = RemoveHeaderDataTypes([.. Bytes]);
+        if (contentBytes == null || contentBytes.Count < _minBytes) { return []; }
+
+        var head = GetHeadAndSetEditor();
+        if (head == null || head.Count < 100) { return []; }
+
+        return [.. head, .. contentBytes];
+    }
+
+    /// <summary>
+    /// Prüft, ob Speichern aktuell erlaubt ist.
+    /// </summary>
+    public override bool IsSaveAbleNow() {
+        if (!base.IsSaveAbleNow()) { return false; }
+        if (LoadFailed) { return false; }
+        if (_writeBuffer != null && _writeBuffer.Count < _minBytes) { return false; }
+        return true;
+    }
+
+    /// <summary>
+    /// Speichert asynchron — nutzt GetContent() und die Backup-Rotation der Basisklasse.
+    /// </summary>
     public override async Task<string> DoExtendedSave() {
-        return await Task.Run(() => {
+        return await Task.Run(async () => {
             var filename = Filename;
             Develop.Message(ErrorType.DevelopInfo, this, MainFileName.FileNameWithSuffix(), ImageCode.Diskette, $"Speichere Chunk '{filename.FileNameWithoutSuffix()}'", 0);
 
-            var backup = filename.FilePath() + filename.FileNameWithoutSuffix() + ".bak";
-            var tempfile = TempFile(filename.FilePath() + filename.FileNameWithoutSuffix() + ".tmp-" + UserName.ToUpperInvariant());
+            var result = await base.DoExtendedSave().ConfigureAwait(false);
 
-            var f = Save(tempfile);
-            if (!string.IsNullOrEmpty(f)) { return f; }
-
-            var tempFileInfo = GetFileState(tempfile, true, 60);
-            if (string.IsNullOrEmpty(tempFileInfo)) {
-                DeleteFile(tempfile, false);
-                return "Dateiinfo konnte nicht gelesen werden";
+            if (string.IsNullOrEmpty(result)) {
+                _minBytes = (int)(Bytes.Count * 0.1);
+                Pause(1, false);
             }
 
-            if (FileExists(backup) && !DeleteFile(backup, false)) {
-                DeleteFile(tempfile, false);
-                return "Backup konnte nicht gelöscht werden";
-            }
-
-            if (FileExists(filename) && !MoveFile(filename, backup, false)) {
-                DeleteFile(tempfile, false);
-                return "Hauptdatei konnte nicht verschoben werden";
-            }
-
-            // --- TmpFile wird zum Haupt ---
-            const int maxRetries = 8;
-            const int retryDelayMs = 1000;
-
-            for (var attempt = 1; attempt <= maxRetries; attempt++) {
-                if (MoveFile(tempfile, filename, false)) {
-                    Invalidate();
-                    _isSaved = true;
-                    Pause(1, false);
-                    return string.Empty;
-                }
-
-                Thread.Sleep(retryDelayMs * attempt);
-
-                // Haupt-Datei ist von irgendwo anders her wieder erstellt worden.
-                if (FileExists(filename)) {
-                    DeleteFile(tempfile, false);
-                    LoadBytesFromDisk(true);
-                    return "Dateien wurden zwischenzeitlich verändert";
-                }
-
-                if (!FileExists(tempfile)) {
-                    break; // Raus aus der Schleife -> Rollback
-                }
-            }
-
-            // ROLLBACK: Backup wiederherstellen bei jedem Fehlerfall
-            if (FileExists(backup) && !FileExists(filename)) {
-                MoveFile(backup, filename, false);
-            }
-
-            DeleteFile(tempfile, false);
-            return "Speichervorgang unerwartet abgebrochen";
+            return result;
         }).ConfigureAwait(false);
     }
 
@@ -522,8 +455,6 @@ public class Chunk : CachedFile, IHasKeyName {
     /// <summary>
     /// Diese Methode entfernt alle bekannten Header-Datentypen, unabhängig von ihrer Position
     /// </summary>
-    /// <param name="bytes">Die zu verarbeitenden Bytes</param>
-    /// <returns>Eine Liste von Bytes ohne Header-Daten oder null bei Fehlern</returns>
     private static List<byte>? RemoveHeaderDataTypes(byte[]? bytes) {
         if (bytes == null) { return null; }
         if (bytes.Length == 0) { return []; }
@@ -531,19 +462,15 @@ public class Chunk : CachedFile, IHasKeyName {
         var result = new List<byte>(bytes.Length);
         var pointer = 0;
 
-        // Durch alle Datensätze gehen
         while (pointer < bytes.Length) {
             var startPointer = pointer;
             var (newPointer, type, _, _, _) = Table.Parse(bytes, pointer);
 
-            // Wenn Parse keine Fortschritte macht, abbrechen um Endlosschleife zu vermeiden
             if (newPointer <= startPointer) {
                 return null;
             }
 
-            // Nur Nicht-Header-Datensätze zum Ergebnis hinzufügen
             if (!type.IsHeaderType() && !type.IsObsolete()) {
-                // Kompletten Datensatz hinzufügen
                 for (var i = startPointer; i < newPointer; i++) {
                     result.Add(bytes[i]);
                 }
@@ -560,14 +487,12 @@ public class Chunk : CachedFile, IHasKeyName {
 
         var headBytes = new List<byte>();
 
-        // Zuerst Werte setzen
         LastEditTimeUtc = DateTime.UtcNow;
         LastEditUser = UserName;
         LastEditApp = Develop.AppExe();
         LastEditMachineName = Environment.MachineName;
         LastEditID = MyId;
 
-        // Dann die Werte zur ByteList hinzufügen
         SaveToByteList(headBytes, TableDataType.Version, Table.TableVersion);
         SaveToByteList(headBytes, TableDataType.Werbung, "                                                                    BlueTable - (c) by Christian Peter                                                                                        ");
 


### PR DESCRIPTION
- CachedFile: IHasKeyName, virtual GetContent/IsSaveAbleNow, MarkDirty, SaveAs, Invalidate setzt _isSaved=true, _isSaved private
- CachedTextFile: statische Block-Datei-Methoden (Create/Age/Read)
- CachedFileSystem: Singleton mit mehreren Watchern (1 pro Verzeichnis), Block-Methoden entfernt, StaleCheckCallback Reihenfolge korrigiert
- MultiUserFile: IHasKeyName/IParseable/INotifyPropertyChanged aus Klassensignatur entfernt, GetContent() überschreibt, Load_Reload inline-Parse, SaveAs/TrySaveAs entfernt (jetzt in CachedFile), MarkDirty statt _isSaved
- Chunk: public Save(string) entfernt, GetContent() implementiert, DoExtendedSave delegiert an Basisklasse
- ConnectedFormulaEditor: btnNeuDB_SaveAs_Click repariert